### PR TITLE
Apply modifier to Scaffold in ArtMaker

### DIFF
--- a/artmaker/src/main/java/io/artmaker/ArtMaker.kt
+++ b/artmaker/src/main/java/io/artmaker/ArtMaker.kt
@@ -108,8 +108,9 @@ fun ArtMaker(
                 }
             }
         },
+        modifier = modifier,
     ) { values ->
-        Column(modifier = modifier.padding(values)) {
+        Column(modifier = Modifier.padding(values)) {
             ArtMakerDrawScreen(
                 modifier = Modifier
                     .fillMaxSize()


### PR DESCRIPTION
Closes #69

Currently, the ArtMaker composable has a Scaffold and a Column inside. As the parent, the Scaffold should be the one getting the modifier variable exposed by ArtMaker instead of the column inside.