### PR TITLE
Viewmodel and Datastore Migration 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
     alias(libs.plugins.org.jlleitschuh.gradle.ktlint)
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.serialization) apply false
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.multiplatform) apply false
 }
 subprojects {
     apply(plugin = rootProject.libs.plugins.spotless.get().pluginId)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ uiTestManifest="1.7.1"
 junit4UiTest="1.7.1"
 composeMaterial3="1.3.0"
 composeBom = "2024.04.01"
+compose = "1.6.11"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
@@ -56,3 +57,5 @@ org-jlleitschuh-gradle-ktlint ={ id = "org.jlleitschuh.gradle.ktlint", version.r
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 vanniktech = {id = "com.vanniktech.maven.publish", version.ref = "vanniktechVersion"}
 serialization={id="org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
+multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }


### PR DESCRIPTION
This PR does two things, 
1. Migrating viewmodel to the shared module. Implementing this was a bit straight-forward, while reviewing it would be easy to follow since no implementation has been changed. 
2. Datastore migration from sharedPreference. For this: 

- I have removed ArtmakerSharedPreference(I have commented this but I don't think we will need this class anymore).
-  Inside the `PreferencesManager` is where the datastore logic has been implemented. All set and get values are exactly as it were before, with suspend being introduced while `setting` the values and returning a Flow while `getting` the values. 
- ArtMakerViewModel handles the logic to update the datastore values, so the coroutine observing the suspend function would be the `viewmodelScope`.  Implementing the functions depending on datastore has not been changed, the logic here would be: The preference would update the values being set, then update the uiState with the values we collect from the preference. 
- CustomColorsManager is where I would like you to a third eye while reviewing this class because, its a bit different and since I am not able to test if its working, you could follow the logic. `getColors` returns a Flow of List of Ints and the value we emit is what we get from the datastore. Saving the color, we collect the values of `getColors` and implement it as it was before. `jsonStr` from the `saveColor` migrates to datastore. 

> [!WARNING]  
> Artmaker has compile errors which was not the focus of this PR. However, Shared module looks good