### PR TITLE
Add stack implementation

### DIFF
--- a/shared/src/commonMain/kotlin/com/fbada006/shared/drawing/DrawingManager.kt
+++ b/shared/src/commonMain/kotlin/com/fbada006/shared/drawing/DrawingManager.kt
@@ -15,27 +15,26 @@
  */
 package com.fbada006.shared.drawing
 
-//import android.graphics.PointF
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import com.fbada006.shared.actions.DrawEvent
 import com.fbada006.shared.actions.UndoRedoEventType
+import com.fbada006.shared.models.PointF
 import com.fbada006.shared.models.PointsData
-//import io.artmaker.utils.erasePointData
+import com.fbada006.shared.utils.erasePointData
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-//import java.util.Stack
 import kotlin.properties.Delegates
 
 /**
  * The drawing manager will handle all the logic related to drawing including clearing, undo, and redo
  */
 internal class DrawingManager {
-//    private val undoStack = Stack<com.fbada006.shared.actions.UndoRedoEventType>()
-//    private val redoStack = Stack<com.fbada006.shared.actions.UndoRedoEventType>()
+    private val undoStack = ArrayDeque<UndoRedoEventType>()
+    private val redoStack = ArrayDeque<UndoRedoEventType>()
 
     private val _pathList = mutableStateListOf<PointsData>()
     val pathList: SnapshotStateList<PointsData> = _pathList
@@ -65,9 +64,9 @@ internal class DrawingManager {
             strokeWidth = strokeWidth.toFloat(),
             alphas = mutableStateListOf(pressure),
         )
-//        undoStack.push(com.fbada006.shared.actions.UndoRedoEventType.BeforeErase(data))
+        undoStack.addLast(UndoRedoEventType.BeforeErase(data))
         _pathList.add(data)
-//        redoStack.clear()
+        redoStack.clear()
         _undoRedoState.update { computeUndoRedoState() }
     }
 
@@ -85,69 +84,69 @@ internal class DrawingManager {
     }
 
     private fun redo() {
-//        if (redoStack.isEmpty()) return
-//        when (val action = redoStack.pop()) {
-//            is com.fbada006.shared.actions.UndoRedoEventType.BeforeErase -> {
-//                undoStack.push(com.fbada006.shared.actions.UndoRedoEventType.BeforeErase(action.pathData))
-//                _pathList.add(action.pathData)
-//            }
-//            is com.fbada006.shared.actions.UndoRedoEventType.AfterErase -> {
-//                undoStack.push(com.fbada006.shared.actions.UndoRedoEventType.AfterErase(_pathList.toList(), action.newState))
-//                _pathList.clear()
-//                _pathList.addAll(action.newState)
-//            }
-//        }
-//        _undoRedoState.update { computeUndoRedoState() }
+        if (redoStack.isEmpty()) return
+        when (val action = redoStack.removeLast()) {
+            is UndoRedoEventType.BeforeErase -> {
+                undoStack.addLast(UndoRedoEventType.BeforeErase(action.pathData))
+                _pathList.add(action.pathData)
+            }
+            is UndoRedoEventType.AfterErase -> {
+                undoStack.addLast(UndoRedoEventType.AfterErase(_pathList.toList(), action.newState))
+                _pathList.clear()
+                _pathList.addAll(action.newState)
+            }
+        }
+        _undoRedoState.update { computeUndoRedoState() }
     }
 
     private fun undo() {
-//        if (undoStack.isEmpty()) return
-//        when (val action = undoStack.pop()) {
-//            is com.fbada006.shared.actions.UndoRedoEventType.BeforeErase -> {
-//                redoStack.push(com.fbada006.shared.actions.UndoRedoEventType.BeforeErase(_pathList.removeLast()))
-//            }
-//            is com.fbada006.shared.actions.UndoRedoEventType.AfterErase -> {
-//                redoStack.push(com.fbada006.shared.actions.UndoRedoEventType.AfterErase(_pathList.toList(), action.newState))
-//                _pathList.clear()
-//                _pathList.addAll(action.oldState)
-//            }
-//        }
-//        _undoRedoState.update { computeUndoRedoState() }
+        if (undoStack.isEmpty()) return
+        when (val action = undoStack.removeLast()) {
+            is UndoRedoEventType.BeforeErase -> {
+                redoStack.addLast(UndoRedoEventType.BeforeErase(_pathList.removeLast()))
+            }
+            is UndoRedoEventType.AfterErase -> {
+                redoStack.addLast(UndoRedoEventType.AfterErase(_pathList.toList(), action.newState))
+                _pathList.clear()
+                _pathList.addAll(action.oldState)
+            }
+        }
+        _undoRedoState.update { computeUndoRedoState() }
     }
 
     private fun clear() {
         _pathList.clear()
-//        redoStack.clear()
-//        undoStack.clear()
+        redoStack.clear()
+        undoStack.clear()
         _undoRedoState.update { computeUndoRedoState() }
     }
 
     private fun computeUndoRedoState(): UndoRedoState = UndoRedoState(
-//        canUndo = undoStack.isNotEmpty(),
-//        canRedo = redoStack.isNotEmpty(),
-//        canClear = _pathList.isNotEmpty() || undoStack.isNotEmpty() || redoStack.isNotEmpty(),
-//        canErase = _pathList.isNotEmpty(),
+        canUndo = undoStack.isNotEmpty(),
+        canRedo = redoStack.isNotEmpty(),
+        canClear = _pathList.isNotEmpty() || undoStack.isNotEmpty() || redoStack.isNotEmpty(),
+        canErase = _pathList.isNotEmpty(),
     )
 
     private fun erase(offset: Offset) {
-//        val erasedPoint = PointF(offset.x, offset.y)
-//        // Store the old state before erasing
-//        val oldPath = _pathList.toList()
-//        val newPath = erasePointData(
-//            pointsData = _pathList,
-//            erasedPoints = arrayOf(erasedPoint),
-//            eraseRadius = strokeWidth.toFloat(),
-//        )
-//        // Only push to undoStack if there's an actual change
-//        if (oldPath != newPath) {
-//            undoStack.push(com.fbada006.shared.actions.UndoRedoEventType.AfterErase(oldPath, newPath))
-//            // Clear the existing points and add the new points
-//            _pathList.clear()
-//            _pathList.addAll(newPath)
-//
-//            redoStack.clear()
-//            _undoRedoState.update { computeUndoRedoState() }
-//        }
+        val erasedPoint = PointF(offset.x, offset.y)
+        // Store the old state before erasing
+        val oldPath = _pathList.toList()
+        val newPath = erasePointData(
+            pointsData = _pathList,
+            erasedPoints = arrayOf(erasedPoint),
+            eraseRadius = strokeWidth.toFloat(),
+        )
+        // Only push to undoStack if there's an actual change
+        if (oldPath != newPath) {
+            undoStack.addLast(UndoRedoEventType.AfterErase(oldPath, newPath))
+            // Clear the existing points and add the new points
+            _pathList.clear()
+            _pathList.addAll(newPath)
+
+            redoStack.clear()
+            _undoRedoState.update { computeUndoRedoState() }
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/fbada006/shared/models/PointF.kt
+++ b/shared/src/commonMain/kotlin/com/fbada006/shared/models/PointF.kt
@@ -1,0 +1,6 @@
+package com.fbada006.shared.models
+
+/**
+ * A simple wrapper around the PointF class working with a float
+ */
+data class PointF(val x: Float, val y: Float)

--- a/shared/src/commonMain/kotlin/com/fbada006/shared/utils/EraserHelper.kt
+++ b/shared/src/commonMain/kotlin/com/fbada006/shared/utils/EraserHelper.kt
@@ -15,12 +15,13 @@
  */
 @file:JvmName("EraserHelper")
 
-package io.artmaker.utils
+package com.fbada006.shared.utils
 
-import android.graphics.PointF
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.geometry.Offset
+import com.fbada006.shared.models.PointF
 import com.fbada006.shared.models.PointsData
+import kotlin.jvm.JvmName
 import kotlin.math.pow
 
 private const val MIN_ERASE_RADIUS = 30F
@@ -32,10 +33,10 @@ private const val MAX_ERASE_RADIUS = 40F
  * @param eraseRadius  Eraser radius.
  * @param erasedPoints Array of eraser points. All lines intersecting circle with {@code eraserRadius} around these points will be erased.
  */
-internal fun erasePointData(pointsData: List<com.fbada006.shared.models.PointsData>, eraseRadius: Float, vararg erasedPoints: PointF): List<com.fbada006.shared.models.PointsData> {
+internal fun erasePointData(pointsData: List<PointsData>, eraseRadius: Float, vararg erasedPoints: PointF): List<PointsData> {
     val hitEraseRadius = eraseRadius.coerceIn(MIN_ERASE_RADIUS, MAX_ERASE_RADIUS)
     val hitRadiusSqr = hitEraseRadius.toDouble().pow(2.0).toFloat()
-    val newPointData = ArrayList<com.fbada006.shared.models.PointsData>(pointsData.size)
+    val newPointData = ArrayList<PointsData>(pointsData.size)
     val indexesToDelete = ArrayList<Int>()
 
     for (pd in pointsData) {
@@ -60,7 +61,7 @@ internal fun erasePointData(pointsData: List<com.fbada006.shared.models.PointsDa
                     val newPoints = SnapshotStateList<Offset>()
                     newPoints.addAll(pd.points.subList(startIdx, indexToDelete))
                     newPointData.add(
-                        com.fbada006.shared.models.PointsData(
+                        PointsData(
                             points = newPoints,
                             strokeWidth = pd.strokeWidth,
                             strokeColor = pd.strokeColor,
@@ -75,7 +76,7 @@ internal fun erasePointData(pointsData: List<com.fbada006.shared.models.PointsDa
                 val newPoints = SnapshotStateList<Offset>()
                 newPoints.addAll(pd.points.subList(startIdx, pd.points.size))
                 newPointData.add(
-                    com.fbada006.shared.models.PointsData(
+                    PointsData(
                         points = newPoints,
                         strokeWidth = pd.strokeWidth,
                         strokeColor = pd.strokeColor,


### PR DESCRIPTION
closes #103 

This PR brings back the stack-like functionality using the `ArrayDeque` in the kotlin collections, which is a better aproach. More details in the issue. This solution also saves us the time and effort it would have taken to implement the stack ourselves