### PR TITLE
Improve finding the context in android image picker

### DIFF
--- a/artmaker/src/androidMain/kotlin/io/fbada006/artmaker/utils/ImagePicker.android.kt
+++ b/artmaker/src/androidMain/kotlin/io/fbada006/artmaker/utils/ImagePicker.android.kt
@@ -16,8 +16,8 @@
 package io.fbada006.artmaker.utils
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.graphics.BitmapFactory
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -25,7 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 
-internal actual class ImagePicker(private val activity: ComponentActivity) {
+internal actual class ImagePicker(private val activity: Activity) {
     private lateinit var getContent: ActivityResultLauncher<String>
 
     @SuppressLint("ComposableNaming")

--- a/artmaker/src/androidMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.android.kt
+++ b/artmaker/src/androidMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.android.kt
@@ -31,9 +31,8 @@ internal actual fun createPicker(): ImagePicker? {
 }
 
 // Helper to recursively find the activity from the context
-private tailrec fun Context.findActivity(): Activity? =
-    when (this) {
-        is Activity -> this
-        is ContextWrapper -> baseContext.findActivity()
-        else -> null
-    }
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/artmaker/src/androidMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.android.kt
+++ b/artmaker/src/androidMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.android.kt
@@ -23,17 +23,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 
 @Composable
-internal actual fun createPicker(): ImagePicker {
+internal actual fun createPicker(): ImagePicker? {
     val activity = LocalContext.current.findActivity()
     return remember(activity) {
-        ImagePicker(activity)
+        if (activity != null) ImagePicker(activity) else null
     }
 }
 
 // Helper to recursively find the activity from the context
-private tailrec fun Context.findActivity(): Activity =
+private tailrec fun Context.findActivity(): Activity? =
     when (this) {
         is Activity -> this
         is ContextWrapper -> baseContext.findActivity()
-        else -> throw IllegalArgumentException("Cannot find activity from this context")
+        else -> null
     }

--- a/artmaker/src/androidMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.android.kt
+++ b/artmaker/src/androidMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.android.kt
@@ -15,15 +15,25 @@
  */
 package io.fbada006.artmaker.utils
 
-import androidx.activity.ComponentActivity
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 
 @Composable
 internal actual fun createPicker(): ImagePicker {
-    val activity = LocalContext.current as ComponentActivity
+    val activity = LocalContext.current.findActivity()
     return remember(activity) {
         ImagePicker(activity)
     }
 }
+
+// Helper to recursively find the activity from the context
+private tailrec fun Context.findActivity(): Activity =
+    when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> throw IllegalArgumentException("Cannot find activity from this context")
+    }

--- a/artmaker/src/commonMain/kotlin/io/fbada006/artmaker/composables/ArtMakerControlMenu.kt
+++ b/artmaker/src/commonMain/kotlin/io/fbada006/artmaker/composables/ArtMakerControlMenu.kt
@@ -101,7 +101,7 @@ internal fun ArtMakerControlMenu(
     /**
      * Before we Pick the Image, we first need to register the picker and set the background Image
      */
-    imagePicker.registerPicker { image ->
+    imagePicker?.registerPicker { image ->
         setBackgroundImage(image)
     }
     var areImageOptionsExpanded by remember { mutableStateOf(false) }
@@ -170,7 +170,7 @@ internal fun ArtMakerControlMenu(
                         if (imageBitmap != null) {
                             areImageOptionsExpanded = true
                         } else {
-                            imagePicker.pickImage()
+                            imagePicker?.pickImage()
                         }
                     },
                 )
@@ -191,7 +191,7 @@ internal fun ArtMakerControlMenu(
                             Text(text = stringResource(Res.string.change_image))
                         },
                         onClick = {
-                            imagePicker.pickImage()
+                            imagePicker?.pickImage()
                             areImageOptionsExpanded = false
                         },
                     )

--- a/artmaker/src/commonMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.kt
+++ b/artmaker/src/commonMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.kt
@@ -21,4 +21,4 @@ import androidx.compose.runtime.Composable
  * Creates a platform specific image picker
  */
 @Composable
-internal expect fun createPicker(): ImagePicker
+internal expect fun createPicker(): ImagePicker?

--- a/artmaker/src/iosMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.ios.kt
+++ b/artmaker/src/iosMain/kotlin/io/fbada006/artmaker/utils/ImagePickerFactory.ios.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.interop.LocalUIViewController
 
 @Composable
-internal actual fun createPicker(): ImagePicker {
+internal actual fun createPicker(): ImagePicker? {
     val rootController = LocalUIViewController.current
     return remember {
         ImagePicker(rootController)


### PR DESCRIPTION
In the `ImagePickerFactory`, we were getting the activity by casting the context straight to an activity. This is potentially dangerous since context may be wrapped around a context wrapper. This code reduces the chances of such an issue happening. 